### PR TITLE
Allow backend version to be displayed in the frontend

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -3,7 +3,7 @@
 const consola = require('consola');
 const Hapi = require('@hapi/hapi');
 const HapiPino = require('hapi-pino');
-
+const { version } = require('./package.json');
 const { setRoutes } = require('./route');
 
 process.on('unhandledRejection', (err) => {
@@ -34,6 +34,12 @@ async function start () {
         }
       }
     }
+  });
+
+  server.route({
+    method: 'GET',
+    path: '/api/v1/version',
+    handler: (request, h) => version
   });
 
   server.events.on('log', (event, tags) => {

--- a/backend/index.js
+++ b/backend/index.js
@@ -39,7 +39,7 @@ async function start () {
   server.route({
     method: 'GET',
     path: '/api/v1/version',
-    handler: (request, h) => version
+    handler: () => version
   });
 
   server.events.on('log', (event, tags) => {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -12,7 +12,8 @@
     <div class="accent-bar top"/>
     <div class="accent-bar bottom"/>
     <div class="version">
-      <h6>Backend Version: {{version}}</h6>
+      <p>Frontend Version: {{frontendVersion}}</p>
+      <p>Backend Version: {{backendVersion}}</p>
     </div>
   </div>
 </template>
@@ -45,30 +46,36 @@
   bottom: 0;
   right: 0;
 
-  h6 {
+  p {
     color: rgb(117, 117, 117);
+    font-weight: 900;
   }
 }
 </style>
 
 <script>
 import { ApiService } from "./services/apiService";
+import { version } from '../package.json'
 
 export default {
   name: "App",
   data() {
     return {
       version: null,
+      frontendVersion: null,
+      backendVersion: null,
       errorMessage: null
     };
   },
   created() {
     const apiService = new ApiService();
+    
+    this.frontendVersion = version;
 
     apiService
       .get(`/api/v1/version`)
-      .then(res => (this.version = res.data))
-      .catch(({ request }) => this.version = "Unknown");
+      .then(res => (this.backendVersion = res.data))
+      .catch(({ request }) => this.backendVersion = "Unknown");
   }
 };
 </script>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -11,6 +11,9 @@
     </div>
     <div class="accent-bar top"/>
     <div class="accent-bar bottom"/>
+    <div class="version">
+      <h6>Backend Version: {{version}}</h6>
+    </div>
   </div>
 </template>
 
@@ -27,7 +30,52 @@
   margin-bottom: 0;
   padding-bottom: 0;
 
-  &.top { top: 0; }
-  &.bottom { bottom: 0; background-color: $least-blue }
+  &.top {
+    top: 0;
+  }
+  &.bottom {
+    bottom: 0;
+    background-color: $least-blue;
+  }
+}
+
+.version {
+  margin: 10px;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+
+  h6 {
+    color: rgb(117, 117, 117);
+  }
 }
 </style>
+
+<script>
+import { ApiService } from "./services/apiService";
+
+export default {
+  name: "App",
+  data() {
+    return {
+      version: null,
+      errorMessage: null
+    };
+  },
+  created() {
+    const apiService = new ApiService();
+
+    apiService
+      .get(`/api/v1/version`)
+      .then(res => (this.version = res.data))
+      .catch(({ request }) => {
+        this.version = "not found";
+        if (request.status === 404) {
+          this.errorMessage = "No version found.";
+        } else {
+          this.errorMessage = "Failed to fetch results.";
+        }
+      });
+  }
+};
+</script>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -68,14 +68,7 @@ export default {
     apiService
       .get(`/api/v1/version`)
       .then(res => (this.version = res.data))
-      .catch(({ request }) => {
-        this.version = "not found";
-        if (request.status === 404) {
-          this.errorMessage = "No version found.";
-        } else {
-          this.errorMessage = "Failed to fetch results.";
-        }
-      });
+      .catch(({ request }) => this.version = "Unknown");
   }
 };
 </script>


### PR DESCRIPTION
On the backend:
- I created a route that is responsible for fetching `package.json().version` and allowed the route to respond that to get requests on `/api/v1/version`

On the frontend:
- I used the ApiService that was created in order to create a GET request from the App component
- Since the request returns a promise, I made sure to put an appropriate string inside the `version` variable that supposedly holds the version that is requested from the backend
- Also added some some CS to allow `backend version` to be output on the bottom right corner