### PR TITLE
Issue 34: Fix page width inconsistency

### DIFF
--- a/frontend/src/styles/app.scss
+++ b/frontend/src/styles/app.scss
@@ -10,6 +10,10 @@
   box-sizing: border-box;
 }
 
+html {
+  overflow-y: scroll;
+}
+
 a {
   font-weight: bold;
   color: $blue;


### PR DESCRIPTION
Add `overflow-y: scroll` as suggested in the stackoverflow thread. 
NOTE:  It does add a inactive scrollbar on pages that do not overflow.